### PR TITLE
Fix daysOfTheYear link

### DIFF
--- a/src/dayOfTheYear.js
+++ b/src/dayOfTheYear.js
@@ -12,7 +12,7 @@ exports.getToday = () => axios.get(URL)
 
         return {
             title: $('#mainBannerLink').text(),
-            href: URL + $('#mainBannerLink').attr('href'),
+            href: $('#mainBannerLink').attr('href'),
             imageUrl: $('.banner--home img').attr('src'),
         }
     });


### PR DESCRIPTION
`href` of `#mainBannerLink` already contains the full url.

Link is being generated like: https://www.daysoftheyear.comhttps//www.daysoftheyear.com/days/international-tug-of-war-day/

```html
<a href="https://www.daysoftheyear.com/days/international-tug-of-war-day/" id="mainBannerLink">International Tug-of-War Day</a>
```